### PR TITLE
Add timer functionality (#5)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,8 @@
 //! - [critical](logs::Logger::critical) methods to log messages.
 //!
 //! All configuration can be done using the [cfg()](logs::Logger::cfg) method in conjunction
-//! with the [Options](logs::Options) enumerator.
+//! with the [Options](logs::Options) enumerator. Valid options include adding a timer, logging to
+//! a file, and more.
 //! See the [logs] module for more details.
 
 pub mod logs;

--- a/src/logs.rs
+++ b/src/logs.rs
@@ -10,7 +10,12 @@ use colored::*;
     Logs are output with a unique 16-bit log index.
     Logger also contains an 8-bit options value set by `cfg()`.
  */
-pub struct Logger(u16, u8, Option<std::io::BufWriter<std::fs::File>>);
+pub struct Logger {
+    index: u16,
+    flags: u8,
+    file: Option<std::io::BufWriter<std::fs::File>>,
+    timer: Option<std::time::Instant>,
+}
 
 impl Logger {
     /**
@@ -19,7 +24,12 @@ impl Logger {
         The logger is initialised with a log index of 0.
      */
     pub fn new() -> Self {
-        Logger(0, 0, None)
+        Logger {
+            index: 0,
+            flags: 0,
+            file: None,
+            timer: None,
+        }
     }
 
     /**
@@ -33,28 +43,36 @@ impl Logger {
     pub fn cfg(&mut self, opts: &[Options]) -> &mut Self {
         for &e in opts {
             match e {
-                Options::NoIndex =>   self.1 |= 0b00000001,
-                Options::NoSymbol =>  self.1 |= 0b00000010,
-                Options::NoColor =>   self.1 |= 0b00000100,
-                Options::NoBold =>    self.1 |= 0b00001000,
-                Options::Plain =>     self.1 |= 0b00001100,
-                Options::Basic =>     self.1 |= 0b00001111,
+                Options::NoIndex =>   self.flags |= 0b00000001,
+                Options::NoSymbol =>  self.flags |= 0b00000010,
+                Options::NoColor =>   self.flags |= 0b00000100,
+                Options::NoBold =>    self.flags |= 0b00001000,
+                Options::Plain =>     self.flags |= 0b00001100,
+                Options::Basic =>     self.flags |= 0b00001111,
                 Options::File => {
-                    self.1 |= 0b00010000;
-                    self.2 = Some(
+                    self.flags |= 0b00010000;
+                    self.file = Some(
                         std::io::BufWriter::new(
                         std::fs::File::create("forestry.log").unwrap())
                     );
                 },
                 Options::FileAt(f) => {
-                    self.1 |= 0b00010000;
-                    self.2 = Some(
+                    self.flags |= 0b00010000;
+                    self.file = Some(
                         std::io::BufWriter::new(
                         f.try_clone().unwrap())
                     );
                 },
-                Options::FileOnly =>  self.1 |= 0b00100000,
-                Options::Reset =>     self.1 &= 0b00000000,
+                Options::FileOnly =>  self.flags |= 0b00100000,
+                Options::Timer => {
+                    self.flags |= 0b01000000;
+                    self.timer = Some(std::time::Instant::now());
+                },
+                Options::TimerAt(t) => {
+                    self.flags |= 0b01000000;
+                    self.timer = Some(*t);
+                },
+                Options::Reset =>     self.flags &= 0b00000000,
             }
         }
         self
@@ -62,16 +80,17 @@ impl Logger {
 
     fn fmt_header(&self, lvl: LogLevel) -> String {
         // If neither part of the header is desired, return a blank string.
-        if self.1 & 0b0011 == 0b0011 {
+        if self.flags & 0b0011 == 0b0011 {
             return "".to_string();
         }
         let mut cnt: ColoredString = "".into();
         let mut sym: ColoredString = "".into();
+        let mut tim: ColoredString = "".into();
 
-        if self.1 & 0b0001 == 0 {
-            cnt = format!("{:0>4x}", self.0).into();
+        if self.flags & 0b0001 == 0 {
+            cnt = format!("{:0>4x}", self.index).into();
         }
-        if self.1 & 0b0010 == 0 {
+        if self.flags & 0b0010 == 0 {
             sym = match lvl {
                 LogLevel::Info => "*".into(),
                 LogLevel::Warn => "~".into(),
@@ -80,46 +99,63 @@ impl Logger {
                 LogLevel::Critical => "%".into(),
             };
         }
-        if self.1 & 0b0100 == 0 {
+        if self.flags & 0b01000000 != 0 {
+            let micros = self.timer.unwrap().elapsed().as_micros();
+            let msecs = micros as f64 / 1_000.0;
+            tim = format!("{:.3}ms", msecs).into();
+        }
+        if self.flags & 0b0100 == 0 {
             match lvl {
                 LogLevel::Info => {
                     cnt = cnt.blue();
                     sym = sym.blue();
+                    tim = tim.blue();
                 },
                 LogLevel::Warn => {
                     cnt = cnt.yellow();
                     sym = sym.yellow();
+                    tim = tim.yellow();
                 },
                 LogLevel::Error => {
                     cnt = cnt.red();
                     sym = sym.red();
+                    tim = tim.red();
                 },
                 LogLevel::Success => {
                     cnt = cnt.green();
                     sym = sym.green();
+                    tim = tim.green();
                 },
                 LogLevel::Critical => {
                     cnt = cnt.on_red().white();
                     sym = sym.on_red().white();
+                    tim = tim.on_red().white();
                 },
             }
         }
-        if self.1 & 0b1000 == 0 {
+        if self.flags & 0b1000 == 0 {
             cnt = cnt.bold();
             sym = sym.bold();
+            tim = tim.bold();
         }
-        if self.1 & 0b0011 == 0 {
-            return format!("[{}:{}] ", cnt, sym);
-        } else if self.1 & 0b0001 == 0 {
-            return format!("[{}] ", cnt);
+        let mut res = "".to_string();
+        if self.flags & 0b0011 == 0 {
+            res = format!("[{}:{}]", cnt, sym);
+        } else if self.flags & 0b0001 == 0 {
+            res = format!("[{}]", cnt);
         } else {
-            return format!("[{}] ", sym);
+            res = format!("[{}]", sym);
         }
+        if self.flags & 0b01000000 != 0 {
+            res = format!("{}({})", res, tim);
+        }
+        res.push_str(" ");
+        res
     }
 
     fn fmt_string(&self, lvl: LogLevel, s: &str) -> String {
         let mut fmt: ColoredString = s.into();
-        if self.1 & 0b0100 == 0 {
+        if self.flags & 0b0100 == 0 {
             match lvl {
                 LogLevel::Info => {
                     fmt = fmt.blue()
@@ -138,7 +174,7 @@ impl Logger {
                 },
             }
         }
-        if self.1 & 0b1000 == 0 {
+        if self.flags & 0b1000 == 0 {
             match lvl {
                 LogLevel::Info => {},
                 LogLevel::Warn => {},
@@ -252,30 +288,30 @@ impl Logger {
     }
 
     fn print(&mut self, lvl: LogLevel, string: &str) -> &mut Self {
-        if self.1 & 0b00100000 == 0 {
+        if self.flags & 0b00100000 == 0 {
             eprintln!("{}{}", self.fmt_header(lvl), self.fmt_string(lvl, string));
         }
 
-        if self.1 & 0b00010000 != 0 {
-            let temp = self.1 & 0b00001100;
-            self.1 |= 0b00001100;
+        if self.flags & 0b00010000 != 0 {
+            let temp = self.flags & 0b00001100;
+            self.flags |= 0b00001100;
             // invoke buffered print here while formatting is temporarily plain
             let plain = format!("{}{}\n", self.fmt_header(lvl), self.fmt_string(lvl, string));
-            if self.2.is_none() {
+            if self.file.is_none() {
                 self.warn("File output enabled without file specified.");
             } else {
-                self.2
+                self.file
                     .as_mut()
                     .unwrap()
                     .write(plain.as_bytes())
                     .unwrap();
             }
-            self.1 &= 0b11110011;
-            self.1 |= temp;
+            self.flags &= 0b11110011;
+            self.flags |= temp;
         }
 
-        self.0 = self.0.wrapping_add(1);
-        if self.0 == 0 {
+        self.index = self.index.wrapping_add(1);
+        if self.index == 0 {
             self.warn("Log index overflowed; log index may be inaccurate.");
         }
         self
@@ -285,25 +321,21 @@ impl Logger {
 /**
     Formatting options for the `Logger`.
     
-    - `File`: Logs to the default file (`forestry.log`).
-    - `FileAt(&'a std::fs::File)`: Logs to a specified file.
-    - `FileOnly`: Only logs to the file; requires `File` or `FileAt`.
     - `NoIndex`: Removes the incrementing log index.
     - `NoSymbol`: Removes the log type symbol.
     - `NoColor`: Removes all colour sequences.
     - `NoBold`: Removes all bold sequences.
     - `Plain`: Removes all formatting escape characters.
     - `Basic`: Turns this into a bare `eprintln!()` call.
+    - `File`: Logs to the default file (`forestry.log`).
+    - `FileAt(&'a std::fs::File)`: Logs to a specified file.
+    - `FileOnly`: Only logs to the file; requires `File` or `FileAt`.
+    - `Time`: Include a timestamp in the log.
+    - `TimerAt (&'a std::time::Instant)`: Attach an existing timestamp to the log (to allow the use of a runtime timer within one's own program as the timer).
     - `Reset`: Resets the logger's formatter to default settings.
  */
 #[derive(Copy, Clone)]
 pub enum Options <'a> {
-    /// Logs to the default file
-    File,
-    /// Logs to a specified file
-    FileAt(&'a std::fs::File),
-    /// Only logs to the file; requires `File` or `FileAt`.
-    FileOnly,
     /// Removes the incrementing log index.
     NoIndex,
     /// Removes the log type symbol.
@@ -316,6 +348,16 @@ pub enum Options <'a> {
     Plain,
     /// Removes all extras; this is now just `eprintln!()`.
     Basic,
+    /// Logs to the default file
+    File,
+    /// Logs to a specified file
+    FileAt(&'a std::fs::File),
+    /// Only logs to the file; requires `File` or `FileAt`.
+    FileOnly,
+    /// Include a timestamp in the log.
+    Timer,
+    /// Attach an existing timestamp to the log (to allow the use of a runtime timer within one's own program as the timer).
+    TimerAt(&'a std::time::Instant),
     /// Reset the logger's formatter to its default state.
     Reset,
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -120,3 +120,27 @@ fn logger_file_at() {
         .success("success")
         .critical("critical");
 }
+
+#[test]
+fn logger_timer() {
+    println!();
+    let mut l = Logger::new();
+    l.cfg(&[Timer])
+        .info("info")
+        .warn("warning")
+        .error("error")
+        .success("success")
+        .critical("critical");
+}
+
+#[test]
+fn logger_timer_at() {
+    println!();
+    let mut l = Logger::new();
+    l.cfg(&[TimerAt(&std::time::Instant::now())])
+        .info("info")
+        .warn("warning")
+        .error("error")
+        .success("success")
+        .critical("critical");
+}


### PR DESCRIPTION
+ `src/logs.rs`: Added optional timer to `Logger`.
* `src/logs.rs`: Tuple struct `Logger` changed to standard field struct.
+ `src/tests.rs`: Added timer unit tests.
* `src/lib.rs`: Minor doc update

resolves #5 