### PR TITLE
Patch error in `fmt_header()`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "forestry"
 description = "A simple cross-platform CLI logging library for Rust"
-version = "1.6.0"
+version = "1.6.1"
 edition = "2021"
 authors = ["uptu <uptu@uptu.dev>"]
 license = "MIT OR Apache-2.0"

--- a/src/logs.rs
+++ b/src/logs.rs
@@ -37,8 +37,8 @@ impl Logger {
     }
 
     fn fmt_header(&self, lvl: LogLevel) -> String {
-        // If neither part of the header is desired, return a blank string.
-        if self.flags & 0b0011 == 0b0011 {
+        // If no part of the header is desired, return a blank string.
+        if self.flags & 0b01000011 == 0b01000011 {
             return "".to_string();
         }
         let mut cnt: ColoredString = "".into();


### PR DESCRIPTION
- **Patch bug I found during the porting process `fmt_header()` was not patched after adding the timer, and the early return of a blank string didn't take it's corresponding flag bit into account; this has been patched**
- **Increment patch number**
